### PR TITLE
Update ScanditSDK.podspec

### DIFF
--- a/ScanditSDK.podspec
+++ b/ScanditSDK.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.author       = "Scandit"
   s.source       = { :git => "https://github.com/xslim/ScanditSDK.git", :tag => s.version.to_s }
 
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '5.1.1'
   s.requires_arc = false
 
   s.source_files = 'ScanditSDK/*.{h,cpp}'


### PR DESCRIPTION
Plese use the correct platform otherwise any "older than iOS 7" projects will fail to "pod update" this project.

Scandit has got a deployment target of 5.1.1.

Thanks
